### PR TITLE
fix: correct file name generation for individual spoils export

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -743,7 +743,7 @@ $(function () {
     // CUSTOM: Additional export names for all individual spoils
     spoils.forEach(spoil => {
       if (display === spoil.id) {
-        fileName = `${APP_PREFIX}${spoils[0].text.replace(/ /g, '_')}TotalExport_${downloadDate}.csv`;
+        fileName = `${APP_PREFIX}${spoil.text.replace(/ /g, '_')}TotalExport_${downloadDate}.csv`;
       }
     });
     const blob = new Blob([csv], {


### PR DESCRIPTION
I can't believe I missed this, smh.